### PR TITLE
API 응답 문서 작성

### DIFF
--- a/src/common/decorators/api-response-with-dto.decorator.ts
+++ b/src/common/decorators/api-response-with-dto.decorator.ts
@@ -1,0 +1,39 @@
+import { applyDecorators, Type } from '@nestjs/common';
+import { ApiExtraModels, ApiProperty, ApiResponse, getSchemaPath } from '@nestjs/swagger';
+
+export class ResponseDto<T> {
+  @ApiProperty()
+  success: boolean;
+
+  @ApiProperty({ default: 200 })
+  statusCode: number;
+
+  @ApiProperty()
+  message: string;
+
+  @ApiProperty()
+  data: T | T[];
+}
+
+export const ApiResponseWithDto = <T extends Type<any>>(data: T, status = 200) => {
+  return applyDecorators(
+    ApiExtraModels(ResponseDto, data),
+    ApiResponse({
+      status,
+      description: '성공',
+      schema: {
+        allOf: [
+          { $ref: getSchemaPath(ResponseDto) },
+          {
+            properties: {
+              success: {},
+              statusCode: { default: status },
+              message: {},
+              data: { allOf: [{ $ref: getSchemaPath(data) }] },
+            },
+          },
+        ],
+      },
+    }),
+  );
+};

--- a/src/forecast/dto/middle-info.dto.ts
+++ b/src/forecast/dto/middle-info.dto.ts
@@ -26,9 +26,25 @@ export class Day {
 }
 
 export class MiddleInfoDto {
-  @ApiProperty({ description: '요청 요일' })
+  @ApiProperty({ description: '요청 요일', example: '화요일' })
   requestDay: string;
 
-  @ApiProperty()
+  @ApiProperty({
+    example: [
+      {
+        day: '화요일',
+        tmpMin: 17,
+        tmpMax: 26,
+        am: {
+          precipitation: 60,
+          weather: '맑음',
+        },
+        pm: {
+          precipitation: 0,
+          weather: '맑음',
+        },
+      },
+    ],
+  })
   informations: Day[];
 }

--- a/src/forecast/dto/middle-info.dto.ts
+++ b/src/forecast/dto/middle-info.dto.ts
@@ -1,0 +1,34 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class HalfOfDay {
+  @ApiProperty({ description: '강수확률' })
+  precipitation: number;
+
+  @ApiProperty({ description: '하늘상태' })
+  weather: string;
+}
+
+export class Day {
+  @ApiProperty()
+  day: string;
+
+  @ApiProperty()
+  tmpMin: number;
+
+  @ApiProperty()
+  tmpMax: number;
+
+  @ApiProperty()
+  am: HalfOfDay;
+
+  @ApiProperty()
+  pm: HalfOfDay;
+}
+
+export class MiddleInfoDto {
+  @ApiProperty({ description: '요청 요일' })
+  requestDay: string;
+
+  @ApiProperty()
+  informations: Day[];
+}

--- a/src/forecast/dto/now-info.dto.ts
+++ b/src/forecast/dto/now-info.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class NowInfoDto {
+  @ApiProperty()
+  time: string;
+
+  @ApiProperty({ description: '하늘상태(SKY)코드: 맑음(1), 구름많음(3), 흐림(4)' })
+  sky: string;
+
+  @ApiProperty({ description: '기온' })
+  tmp: string;
+}

--- a/src/forecast/dto/now-info.dto.ts
+++ b/src/forecast/dto/now-info.dto.ts
@@ -1,12 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 export class NowInfoDto {
-  @ApiProperty()
+  @ApiProperty({ example: '1400' })
   time: string;
 
-  @ApiProperty({ description: '하늘상태(SKY)코드: 맑음(1), 구름많음(3), 흐림(4)' })
+  @ApiProperty({ description: '하늘상태(SKY)코드: 맑음(1), 구름많음(3), 흐림(4)', example: '3' })
   sky: string;
 
-  @ApiProperty({ description: '기온' })
+  @ApiProperty({ description: '기온', example: '27' })
   tmp: string;
 }

--- a/src/forecast/dto/today-info.dto.ts
+++ b/src/forecast/dto/today-info.dto.ts
@@ -1,0 +1,70 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class MaxPop {
+  @ApiProperty({ description: '최대 강수확률' })
+  value: string;
+
+  @ApiProperty({ description: '최대 강수확률에 해당하는 시간대의 첫번째 값' })
+  time: string;
+}
+
+export class Report {
+  @ApiProperty({ description: '최대 기온' })
+  maxTmp: number;
+
+  @ApiProperty({ description: '최소 기온' })
+  minTmp: number;
+
+  @ApiProperty({ description: '최대 강수확률' })
+  maxPop: MaxPop;
+}
+
+export class Finedust {
+  @ApiProperty({ description: '행정구역 이름' })
+  sidoName: string;
+
+  @ApiProperty({ description: '미세먼지' })
+  pm10: string;
+
+  @ApiProperty({ description: '초미세먼지' })
+  pm25: string;
+}
+
+export class WeatherMetadata {
+  @ApiProperty()
+  date: string;
+
+  @ApiProperty()
+  time: string;
+
+  @ApiProperty({ description: '하늘상태(SKY)코드: 맑음(1), 구름많음(3), 흐림(4)' })
+  sky: string;
+
+  @ApiProperty({ description: '기온' })
+  tmp: string;
+
+  @ApiProperty({ description: '강수확률' })
+  pop: string;
+}
+
+export class Day {
+  @ApiProperty()
+  report: Report;
+
+  @ApiProperty({ description: '미세먼지' })
+  fineDust?: Finedust;
+
+  @ApiProperty({ description: '시간대별 날씨 정보' })
+  timeline: WeatherMetadata[];
+}
+
+export class TodayInfoDto {
+  @ApiProperty()
+  today: Day;
+
+  @ApiProperty()
+  tomorrow: Day;
+
+  @ApiProperty()
+  tmp: Day;
+}

--- a/src/forecast/dto/today-info.dto.ts
+++ b/src/forecast/dto/today-info.dto.ts
@@ -1,18 +1,18 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, PickType } from '@nestjs/swagger';
 
 export class MaxPop {
-  @ApiProperty({ description: '최대 강수확률' })
+  @ApiProperty({ description: '최대 강수확률', example: '60' })
   value: string;
 
-  @ApiProperty({ description: '최대 강수확률에 해당하는 시간대의 첫번째 값' })
+  @ApiProperty({ description: '최대 강수확률에 해당하는 시간대의 첫번째 값', example: '0300' })
   time: string;
 }
 
 export class Report {
-  @ApiProperty({ description: '최대 기온' })
+  @ApiProperty({ description: '최대 기온', example: 26 })
   maxTmp: number;
 
-  @ApiProperty({ description: '최소 기온' })
+  @ApiProperty({ description: '최소 기온', example: 17 })
   minTmp: number;
 
   @ApiProperty({ description: '최대 강수확률' })
@@ -20,13 +20,13 @@ export class Report {
 }
 
 export class Finedust {
-  @ApiProperty({ description: '행정구역 이름' })
+  @ApiProperty({ description: '행정구역 이름', example: '서울' })
   sidoName: string;
 
-  @ApiProperty({ description: '미세먼지' })
+  @ApiProperty({ description: '미세먼지', example: '보통' })
   pm10: string;
 
-  @ApiProperty({ description: '초미세먼지' })
+  @ApiProperty({ description: '초미세먼지', example: '보통' })
   pm25: string;
 }
 
@@ -47,24 +47,37 @@ export class WeatherMetadata {
   pop: string;
 }
 
-export class Day {
+export class Today {
   @ApiProperty()
   report: Report;
 
   @ApiProperty({ description: '미세먼지' })
-  fineDust?: Finedust;
+  fineDust: Finedust;
 
-  @ApiProperty({ description: '시간대별 날씨 정보' })
+  @ApiProperty({
+    description: '시간대별 날씨 정보',
+    example: [
+      {
+        date: '20220426',
+        time: '0300',
+        sky: '4',
+        tmp: '18',
+        pop: '60',
+      },
+    ],
+  })
   timeline: WeatherMetadata[];
 }
 
+export class AfterToday extends PickType(Today, ['report', 'timeline']) {}
+
 export class TodayInfoDto {
   @ApiProperty()
-  today: Day;
+  today: Today;
 
   @ApiProperty()
-  tomorrow: Day;
+  tomorrow: AfterToday;
 
   @ApiProperty()
-  tmp: Day;
+  tmp: AfterToday;
 }

--- a/src/forecast/forecast.controller.ts
+++ b/src/forecast/forecast.controller.ts
@@ -2,45 +2,45 @@ import { Controller, Get, Query } from '@nestjs/common';
 import { ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { ForecastService } from '@forecast/forecast.service';
 import { MiddleForecastService } from '@forecast/middle-forecast.service';
+import { NowInfoDto } from './dto/now-info.dto';
+import { TodayInfoDto } from './dto/today-info.dto';
+import { ApiResponseWithDto } from '@app/common/decorators/api-response-with-dto.decorator';
+import { MiddleInfoDto } from './dto/middle-info.dto';
+
+const latMetadata = {
+  name: 'lat',
+  required: true,
+  type: Number,
+  description: '예보지점 위도',
+  example: '37.48685107621001',
+};
+
+const lonMetadata = {
+  name: 'lon',
+  required: true,
+  type: Number,
+  description: '예보지점 경도',
+  example: '126.83860422707822',
+};
 
 @ApiTags('Weather')
 @Controller('forecast')
 export class ForecastController {
   constructor(private forecastService: ForecastService, private middleForecast: MiddleForecastService) {}
 
-  //TODO: 응답 데코레이터 작성
+  @ApiResponseWithDto(NowInfoDto)
   @ApiOperation({ summary: '지금 날씨 정보 조회' })
-  @ApiQuery({
-    name: 'lat',
-    required: true,
-    type: Number,
-    description: '예보지점 위도',
-  })
-  @ApiQuery({
-    name: 'lon',
-    required: true,
-    type: Number,
-    description: '예보지점 경도',
-  })
+  @ApiQuery(latMetadata)
+  @ApiQuery(lonMetadata)
   @Get('now')
   getNowInfo(@Query('lat') lat: string, @Query('lon') lon: string) {
     return this.forecastService.getNowInfo(lat, lon);
   }
 
-  //TODO: 응답 데코레이터 작성
+  @ApiResponseWithDto(TodayInfoDto)
   @ApiOperation({ summary: '오늘 날씨 정보 조회' })
-  @ApiQuery({
-    name: 'lat',
-    required: true,
-    type: Number,
-    description: '예보지점 위도',
-  })
-  @ApiQuery({
-    name: 'lon',
-    required: true,
-    type: Number,
-    description: '예보지점 경도',
-  })
+  @ApiQuery(latMetadata)
+  @ApiQuery(lonMetadata)
   @Get('today')
   getTodayInfo(@Query('lat') lat: string, @Query('lon') lon: string) {
     // baseDate, baseTime 구하기
@@ -55,19 +55,10 @@ export class ForecastController {
     return this.forecastService.getTodayInfo(lat, lon, baseDate, baseTime);
   }
 
+  @ApiResponseWithDto(MiddleInfoDto)
   @ApiOperation({ summary: '주간 날씨 정보 조회' })
-  @ApiQuery({
-    name: 'lat',
-    required: true,
-    type: Number,
-    description: '예보지점 위도',
-  })
-  @ApiQuery({
-    name: 'lon',
-    required: true,
-    type: Number,
-    description: '예보지점 경도',
-  })
+  @ApiQuery(latMetadata)
+  @ApiQuery(lonMetadata)
   @Get('middle')
   getMiddleInfo(@Query('lat') lat: string, @Query('lon') lon: string) {
     return this.middleForecast.getMiddleForecastInformation(Number(lon), Number(lat));

--- a/src/main.ts
+++ b/src/main.ts
@@ -59,9 +59,9 @@ class Application {
       origin: this.corsOriginList,
       credentials: true,
     });
+    this.setUpGlobalPrefix();
     this.setUpOpenApiAuth();
     this.setUpOpenAPImidleware();
-    this.setUpGlobalPrefix();
     this.server.useGlobalPipes(
       new ValidationPipe({
         whitelist: true,

--- a/src/users/dto/save-user.dto.ts
+++ b/src/users/dto/save-user.dto.ts
@@ -3,11 +3,11 @@ import { IsString } from 'class-validator';
 import { UserEntity } from '../entity/user.entity';
 
 export class SaveUserDto extends PickType(UserEntity, ['id', 'token'] as const) {
-  @ApiProperty({ description: '유저 현재 위치 위도' })
+  @ApiProperty({ description: '유저 현재 위치 위도', example: '37.48599166666667' })
   @IsString()
   lat: string;
 
-  @ApiProperty({ description: '유저 현재 위치 경도' })
+  @ApiProperty({ description: '유저 현재 위치 경도', example: '126.84160833333333' })
   @IsString()
   lon: string;
 }

--- a/src/users/dto/update-user.dto.ts
+++ b/src/users/dto/update-user.dto.ts
@@ -3,11 +3,11 @@ import { IsString } from 'class-validator';
 import { UserEntity } from '../entity/user.entity';
 
 export class UpdateUserDto extends PickType(UserEntity, ['token'] as const) {
-  @ApiProperty({ description: '유저 현재 위치 위도' })
+  @ApiProperty({ description: '유저 현재 위치 위도', example: '37.48599166666667' })
   @IsString()
   lat: string;
 
-  @ApiProperty({ description: '유저 현재 위치 경도' })
+  @ApiProperty({ description: '유저 현재 위치 경도', example: '126.84160833333333' })
   @IsString()
   lon: string;
 }

--- a/src/users/dto/user-response.dto.ts
+++ b/src/users/dto/user-response.dto.ts
@@ -1,7 +1,11 @@
 import { ApiProperty, PickType } from '@nestjs/swagger';
+import { AlarmTimeEntity } from '../entity/alarmTime.entity';
 import { UserEntity } from '../entity/user.entity';
 
-export class UserResponseDto extends PickType(UserEntity, ['id', 'token', 'alarmTimes'] as const) {
+export class UserResponseDto extends PickType(UserEntity, ['id', 'token'] as const) {
+  @ApiProperty()
+  alarmTimes: AlarmTimeEntity[];
+
   @ApiProperty({ description: '유저 현재 위치 행정구역' })
   areaName: string;
 }

--- a/src/users/dto/user-response.dto.ts
+++ b/src/users/dto/user-response.dto.ts
@@ -3,7 +3,7 @@ import { AlarmTimeEntity } from '../entity/alarmTime.entity';
 import { UserEntity } from '../entity/user.entity';
 
 export class UserResponseDto extends PickType(UserEntity, ['id', 'token'] as const) {
-  @ApiProperty()
+  @ApiProperty({ example: [{ id: 14, time: 14 }] })
   alarmTimes: AlarmTimeEntity[];
 
   @ApiProperty({ description: '유저 현재 위치 행정구역' })

--- a/src/users/entity/alarmTime.entity.ts
+++ b/src/users/entity/alarmTime.entity.ts
@@ -1,11 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { Column, Entity, ManyToMany, PrimaryColumn } from 'typeorm';
 import { UserEntity } from './user.entity';
 
 @Entity('AlarmTime')
 export class AlarmTimeEntity {
+  @ApiProperty()
   @PrimaryColumn({ type: 'tinyint' })
   id: number;
 
+  @ApiProperty({ description: '알람 시간' })
   @Column({ type: 'tinyint' })
   time: number;
 

--- a/src/users/entity/user.entity.ts
+++ b/src/users/entity/user.entity.ts
@@ -5,12 +5,12 @@ import { AlarmTimeEntity } from './alarmTime.entity';
 
 @Entity('User')
 export class UserEntity {
-  @ApiProperty({ description: 'UUID' })
+  @ApiProperty({ description: 'UUID', example: 'a4f35968-dc52-48d6-8068-16a6c600bcce' })
   @IsUUID()
   @PrimaryColumn({ length: 40 })
   id: string;
 
-  @ApiProperty({ description: '디바이스 토큰' })
+  @ApiProperty({ description: '디바이스 토큰', example: 'token' })
   @IsString()
   @Column({ nullable: false, length: 255 })
   token: string;

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,6 +1,6 @@
 import { ApiResponseWithDto } from '@app/common/decorators/api-response-with-dto.decorator';
 import { Body, Controller, Delete, Get, Param, ParseIntPipe, Post, Put, Query } from '@nestjs/common';
-import { ApiNoContentResponse, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBody, ApiNoContentResponse, ApiOperation, ApiParam, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { SaveUserDto } from './dto/save-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { UserResponseDto } from './dto/user-response.dto';
@@ -12,6 +12,7 @@ export class UsersController {
   constructor(private usersService: UsersService) {}
 
   @ApiResponseWithDto(UserResponseDto)
+  @ApiParam({ name: 'id', example: 'a4f35968-dc52-48d6-8068-16a6c600bcce' })
   @ApiOperation({ summary: '유저 정보 조회' })
   @Get(':id')
   getUser(@Param('id') id: string) {
@@ -19,6 +20,7 @@ export class UsersController {
   }
 
   @ApiResponseWithDto(UserResponseDto, 201)
+  @ApiBody({ type: SaveUserDto })
   @ApiOperation({ summary: '유저 정보 등록' })
   @Post()
   saveUser(@Body() body: SaveUserDto) {
@@ -28,6 +30,7 @@ export class UsersController {
   }
 
   @ApiResponseWithDto(UserResponseDto)
+  @ApiParam({ name: 'id', example: 'a4f35968-dc52-48d6-8068-16a6c600bcce' })
   @ApiOperation({ summary: '유저 정보 수정' })
   @Put(':id')
   updateUser(@Param('id') id: string, @Body() body: UpdateUserDto) {
@@ -36,7 +39,8 @@ export class UsersController {
     return this.usersService.updateUser(id, token, lat, lon);
   }
 
-  @ApiResponseWithDto(UserResponseDto, 204)
+  @ApiNoContentResponse()
+  @ApiParam({ name: 'id', example: 'a4f35968-dc52-48d6-8068-16a6c600bcce' })
   @ApiOperation({ summary: '유저 정보 삭제' })
   @Delete(':id')
   deleteUser(@Param('id') id: string) {
@@ -49,7 +53,9 @@ export class UsersController {
     required: true,
     type: Number,
     description: '추가할 알람 시간 (0 - 23)',
+    example: '14',
   })
+  @ApiParam({ name: 'userId', example: 'a4f35968-dc52-48d6-8068-16a6c600bcce' })
   @ApiOperation({ summary: '알람 시간 추가' })
   @Post(':userId/alarmTimes')
   addUserAlarmTime(@Param('userId') userId: string, @Query('time', ParseIntPipe) time: number) {
@@ -62,7 +68,9 @@ export class UsersController {
     required: true,
     type: Number,
     description: '삭제할 알람 시간 (0 - 23)',
+    example: '14',
   })
+  @ApiParam({ name: 'userId', example: 'a4f35968-dc52-48d6-8068-16a6c600bcce' })
   @ApiOperation({ summary: '알람 시간 삭제' })
   @Delete(':userId/alarmTimes')
   removeUserAlarmTime(@Param('userId') userId: string, @Query('time', ParseIntPipe) time: number) {

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,7 +1,9 @@
+import { ApiResponseWithDto } from '@app/common/decorators/api-response-with-dto.decorator';
 import { Body, Controller, Delete, Get, Param, ParseIntPipe, Post, Put, Query } from '@nestjs/common';
-import { ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ApiNoContentResponse, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { SaveUserDto } from './dto/save-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { UserResponseDto } from './dto/user-response.dto';
 import { UsersService } from './users.service';
 
 @ApiTags('User')
@@ -9,12 +11,14 @@ import { UsersService } from './users.service';
 export class UsersController {
   constructor(private usersService: UsersService) {}
 
+  @ApiResponseWithDto(UserResponseDto)
   @ApiOperation({ summary: '유저 정보 조회' })
   @Get(':id')
   getUser(@Param('id') id: string) {
     return this.usersService.getUser(id);
   }
 
+  @ApiResponseWithDto(UserResponseDto, 201)
   @ApiOperation({ summary: '유저 정보 등록' })
   @Post()
   saveUser(@Body() body: SaveUserDto) {
@@ -23,6 +27,7 @@ export class UsersController {
     return this.usersService.saveUser(id, token, lat, lon);
   }
 
+  @ApiResponseWithDto(UserResponseDto)
   @ApiOperation({ summary: '유저 정보 수정' })
   @Put(':id')
   updateUser(@Param('id') id: string, @Body() body: UpdateUserDto) {
@@ -31,12 +36,14 @@ export class UsersController {
     return this.usersService.updateUser(id, token, lat, lon);
   }
 
+  @ApiResponseWithDto(UserResponseDto, 204)
   @ApiOperation({ summary: '유저 정보 삭제' })
   @Delete(':id')
   deleteUser(@Param('id') id: string) {
     return this.usersService.deleteUser(id);
   }
 
+  @ApiResponseWithDto(UserResponseDto, 201)
   @ApiQuery({
     name: 'time',
     required: true,
@@ -49,6 +56,7 @@ export class UsersController {
     return this.usersService.addUserAlarmTime(userId, time);
   }
 
+  @ApiResponseWithDto(UserResponseDto)
   @ApiQuery({
     name: 'time',
     required: true,


### PR DESCRIPTION
Close #37 

## 작업 내용
- prefix 값 swagger에 적용되도록 fix (서버에 Swagger 적용 전 prefix 적용해 주면 됨!)
- 응답 common format에 DTO 적용하는 데코레이터 생성
- properties 설명, 예시 값 필요한 곳에 추가

## 주의 사항
- 생성한 응답 데코레이터 사용 시 DTO 내부에 타입이 array인 프로퍼티가 있으면, 해당 배열 내부 값이 문서상 보여지지 않음
- 방법을 찾아봤으나 관련된 자료가 부족하여 일단 프로퍼티 예시 값으로 보여지게 함 (스키마 조회는 안됨😭 그래서 타입이나 설명 조회 불가)
- 그리고 현재까지 개발한 부분 배포할지?